### PR TITLE
Fix API key validation test to match actual error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ git push && \
 gh release create v$VERSION --title "v$VERSION" --generate-notes
 ```
 
+Always add release notes that add value, and only call release with vx.x.x no description in the relese name.
 
 ## Code Style
 - **Typing**: Strict type annotations, use `BaseModel` for structured outputs

--- a/tests/test_ai_batch.py
+++ b/tests/test_ai_batch.py
@@ -64,14 +64,12 @@ def test_missing_api_key():
     """Test that missing API key raises appropriate error."""
     messages = [[{"role": "user", "content": "Test message"}]]
     
-    with pytest.raises(TypeError, match="Could not resolve authentication method"):
+    with pytest.raises(ValueError, match="ANTHROPIC_API_KEY environment variable is required"):
         job = batch(
             messages=messages,
             model="claude-3-haiku-20240307",
             response_model=SpamResult
         )
-        # Try to get results to trigger API error
-        job.results()
 
 
 @patch('batchata.core.get_provider_for_model')

--- a/uv.lock
+++ b/uv.lock
@@ -126,7 +126,7 @@ wheels = [
 
 [[package]]
 name = "batchata"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
- Updated test_missing_api_key to expect ValueError instead of TypeError
- Match actual error message from AnthropicBatchProvider
- Test now passes locally and should work in GitHub Actions