### PR TITLE
Fix Citation serialization issue causing truncated JSON files

### DIFF
--- a/batchata/core/job_result.py
+++ b/batchata/core/job_result.py
@@ -61,7 +61,12 @@ class JobResult:
         citation_mappings = None
         if self.citation_mappings:
             citation_mappings = {
-                field: [asdict(c) for c in citations]
+                field: [{
+                    'text': c.text,
+                    'source': c.source, 
+                    'page': c.page,
+                    'metadata': c.metadata
+                } for c in citations]
                 for field, citations in self.citation_mappings.items()
             }
         
@@ -69,7 +74,12 @@ class JobResult:
             "job_id": self.job_id,
             "raw_response": self.raw_response,
             "parsed_response": parsed_response,
-            "citations": [asdict(c) for c in self.citations] if self.citations else None,
+            "citations": [{
+                'text': c.text,
+                'source': c.source, 
+                'page': c.page,
+                'metadata': c.metadata
+            } for c in self.citations] if self.citations else None,
             "citation_mappings": citation_mappings,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,

--- a/uv.lock
+++ b/uv.lock
@@ -130,7 +130,7 @@ wheels = [
 
 [[package]]
 name = "batchata"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Fixes Citation objects not being JSON serializable, which caused truncated output files and application crashes. 

Problem: JobResult.to_dict() used asdict() on Citation objects, causing JSON serialization to fail mid-write.

Solution: Replace asdict() with manual dict conversion for citations and citation_mappings.

✅ Complete job output files  
✅ No more truncated JSON  
✅ All tests pass