### PR TITLE
Explicitly disable VertexAI in Gemini Provider and update Gemini model configs

### DIFF
--- a/batchata/providers/gemini/gemini_provider.py
+++ b/batchata/providers/gemini/gemini_provider.py
@@ -48,7 +48,7 @@ class GeminiProvider(Provider):
         if not api_key:
             raise ValueError("GOOGLE_API_KEY environment variable is required")
         
-        self.client = genai_lib.Client(api_key=api_key)
+        self.client = genai_lib.Client(vertexai=False, api_key=api_key)
         super().__init__()
         self.models = GEMINI_MODELS
         self._batches: Dict[str, Dict] = {}

--- a/batchata/providers/gemini/models.py
+++ b/batchata/providers/gemini/models.py
@@ -10,8 +10,8 @@ from ..model_config import ModelConfig
 # Google Gemini models with batch processing support
 # Batch mode provides 50% discount on standard API pricing
 GEMINI_MODELS = {
-    "gemini-3.0-pro-preview": ModelConfig(
-        name="gemini-3.0-pro-preview",
+    "gemini-3-pro-preview": ModelConfig(
+        name="gemini-3-pro-preview",
         max_input_tokens=1048576,  # 1M context
         max_output_tokens=65536,
         batch_discount=0.5,  # 50% discount confirmed in docs
@@ -21,8 +21,8 @@ GEMINI_MODELS = {
         supports_structured_output=True,
         file_types=[".pdf", ".txt", ".jpg", ".png", ".webp"]
     ),
-    "gemini-3.0-flash-preview": ModelConfig(
-        name="gemini-3.0-flash-preview",
+    "gemini-3-flash-preview": ModelConfig(
+        name="gemini-3-flash-preview",
         max_input_tokens=1048576,  # 1M context
         max_output_tokens=65536,
         batch_discount=0.5,  # 50% discount confirmed in docs

--- a/batchata/providers/gemini/models.py
+++ b/batchata/providers/gemini/models.py
@@ -2,96 +2,67 @@
 
 from ..model_config import ModelConfig
 
+# updated based on current (Jan 28 2026) docs
+# models - https://ai.google.dev/gemini-api/docs/models
+# batch pricing - https://ai.google.dev/gemini-api/docs/pricing
+# image file types - https://ai.google.dev/gemini-api/docs/image-understanding#supported-formats
 
 # Google Gemini models with batch processing support
 # Batch mode provides 50% discount on standard API pricing
 GEMINI_MODELS = {
-    "gemini-3.0-pro-latest": ModelConfig(
-        name="gemini-3.0-pro-latest",
-        max_input_tokens=2097152,  # 2M context
-        max_output_tokens=8192,
+    "gemini-3.0-pro-preview": ModelConfig(
+        name="gemini-3.0-pro-preview",
+        max_input_tokens=1048576,  # 1M context
+        max_output_tokens=65536,
         batch_discount=0.5,  # 50% discount confirmed in docs
         supports_images=True,
         supports_files=True,
         supports_citations=False,
         supports_structured_output=True,
-        file_types=[".pdf", ".txt", ".jpg", ".png", ".gif", ".webp"]
+        file_types=[".pdf", ".txt", ".jpg", ".png", ".webp"]
     ),
-    "gemini-3.0-pro": ModelConfig(
-        name="gemini-3.0-pro",
-        max_input_tokens=2097152,  # 2M context
-        max_output_tokens=8192,
+    "gemini-3.0-flash-preview": ModelConfig(
+        name="gemini-3.0-flash-preview",
+        max_input_tokens=1048576,  # 1M context
+        max_output_tokens=65536,
         batch_discount=0.5,  # 50% discount confirmed in docs
         supports_images=True,
         supports_files=True,
         supports_citations=False,
         supports_structured_output=True,
-        file_types=[".pdf", ".txt", ".jpg", ".png", ".gif", ".webp"]
+        file_types=[".pdf", ".txt", ".jpg", ".png", ".webp"]
     ),
-    "gemini-3.0-flash-latest": ModelConfig(
-        name="gemini-3.0-flash-latest",
+    "gemini-2.5-pro": ModelConfig(
+        name="gemini-2.5-pro",
         max_input_tokens=1048576,  # 1M context
-        max_output_tokens=8192,
+        max_output_tokens=65536,
         batch_discount=0.5,
         supports_images=True,
         supports_files=True,
         supports_citations=False,
         supports_structured_output=True,
-        file_types=[".pdf", ".txt", ".jpg", ".png", ".gif", ".webp"]
+        file_types=[".pdf", ".txt", ".jpg", ".png", ".webp"]
     ),
-    "gemini-3.0-flash": ModelConfig(
-        name="gemini-3.0-flash",
+    "gemini-2.5-flash": ModelConfig(
+        name="gemini-2.5-flash",
         max_input_tokens=1048576,  # 1M context
-        max_output_tokens=8192,
+        max_output_tokens=65536,
+        batch_discount=0.5,
+        supports_images=True,
+        supports_files=False,
+        supports_citations=False,
+        supports_structured_output=True,
+        file_types=[".txt", ".jpg", ".png", ".webp"]
+    ),
+    "gemini-2.5-flash-lite": ModelConfig(
+        name="gemini-2.5-flash-lite",
+        max_input_tokens=1048576,  # 1M context
+        max_output_tokens=65536,
         batch_discount=0.5,
         supports_images=True,
         supports_files=True,
         supports_citations=False,
         supports_structured_output=True,
-        file_types=[".pdf", ".txt", ".jpg", ".png", ".gif", ".webp"]
-    ),
-    "gemini-3.0-flash-lite-latest": ModelConfig(
-        name="gemini-3.0-flash-lite-latest",
-        max_input_tokens=1048576,  # 1M context
-        max_output_tokens=8192,
-        batch_discount=0.5,
-        supports_images=True,
-        supports_files=True,
-        supports_citations=False,
-        supports_structured_output=True,
-        file_types=[".pdf", ".txt", ".jpg", ".png", ".gif", ".webp"]
-    ),
-    "gemini-3.0-flash-lite": ModelConfig(
-        name="gemini-3.0-flash-lite",
-        max_input_tokens=1048576,  # 1M context
-        max_output_tokens=8192,
-        batch_discount=0.5,
-        supports_images=True,
-        supports_files=True,
-        supports_citations=False,
-        supports_structured_output=True,
-        file_types=[".pdf", ".txt", ".jpg", ".png", ".gif", ".webp"]
-    ),
-    "gemini-2.0-flash": ModelConfig(
-        name="gemini-2.0-flash",
-        max_input_tokens=1048576,  # 1M context
-        max_output_tokens=8192,
-        batch_discount=0.5,
-        supports_images=True,
-        supports_files=True,
-        supports_citations=False,
-        supports_structured_output=True,
-        file_types=[".pdf", ".txt", ".jpg", ".png", ".gif", ".webp"]
-    ),
-    "gemini-2.0-flash-lite": ModelConfig(
-        name="gemini-2.0-flash-lite",
-        max_input_tokens=1048576,  # 1M context
-        max_output_tokens=8192,
-        batch_discount=0.5,
-        supports_images=True,
-        supports_files=True,
-        supports_citations=False,
-        supports_structured_output=True,
-        file_types=[".pdf", ".txt", ".jpg", ".png", ".gif", ".webp"]
-    ),
+        file_types=[".pdf", ".txt", ".jpg", ".png", ".webp"]
+    )
 }


### PR DESCRIPTION
Gemini can be accessed by [two APIs](https://ai.google.dev/gemini-api/docs/migrate-to-cloud) with different capabilities. Only the Gemini Developer API supports inline and local file batch processing, so I've explicitly disabled `vertexai` to prevent the client from automatically detecting if you can use Vertex.

This fix also updates the Gemini model configs and... de-hallucinates them. Anyways, here are the references I used for the configs.
- models, https://ai.google.dev/gemini-api/docs/models
- batch pricing, https://ai.google.dev/gemini-api/docs/pricing
- supported image file types, https://ai.google.dev/gemini-api/docs/image-understanding#supported-formats